### PR TITLE
Refine network tracker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,27 @@ This tutorial focuses mainly on Git and using GitHub as its remote
 This repository is built step by step in the tutorial.
 
 It now includes steps for GitHub.
+
+## WebSocket traffic tracker
+
+This repository includes a simple WebSocket client example in
+`network-tracker/websocket_tracker.cpp`. It connects to a WebSocket endpoint
+specified on the command line and prints any received messages to standard
+output.
+
+### Building
+
+You need `g++`, Boost, and the `websocketpp` library installed. On Ubuntu you can
+install the dependencies and compile with:
+
+```sh
+sudo apt-get install -y libwebsocketpp-dev libboost-system-dev
+g++ -std=c++11 network-tracker/websocket_tracker.cpp -o network-tracker/websocket_tracker -lboost_system -pthread
+```
+
+Run the program by passing a WebSocket URI, for example:
+
+```sh
+./network-tracker/websocket_tracker ws://echo.websocket.events
+```
+

--- a/network-tracker/README.md
+++ b/network-tracker/README.md
@@ -1,0 +1,20 @@
+# network-tracker
+
+This repository contains a simple WebSocket client written in C++ that connects to a specified endpoint and logs all received messages. The example uses `websocketpp` and Boost.Asio.
+
+## Building
+
+Install dependencies and compile with:
+
+```sh
+sudo apt-get install -y libwebsocketpp-dev libboost-system-dev
+g++ -std=c++11 websocket_tracker.cpp -o websocket_tracker -lboost_system -pthread
+```
+
+## Usage
+
+Run the program with the WebSocket URI you want to connect to:
+
+```sh
+./websocket_tracker ws://echo.websocket.events
+```

--- a/network-tracker/websocket_tracker.cpp
+++ b/network-tracker/websocket_tracker.cpp
@@ -1,0 +1,68 @@
+#include <websocketpp/config/asio_no_tls_client.hpp>
+#include <websocketpp/client.hpp>
+
+#include <iostream>
+#include <string>
+
+// Convenience typedefs
+typedef websocketpp::client<websocketpp::config::asio_client> client;
+
+typedef websocketpp::config::asio_client::message_type::ptr message_ptr;
+
+class websocket_endpoint {
+public:
+    websocket_endpoint() {
+        m_endpoint.clear_access_channels(websocketpp::log::alevel::all);
+        m_endpoint.clear_error_channels(websocketpp::log::elevel::all);
+
+        // Initialize ASIO
+        m_endpoint.init_asio();
+
+        // Bind handlers
+        m_endpoint.set_open_handler(std::bind(&websocket_endpoint::on_open, this, std::placeholders::_1));
+        m_endpoint.set_message_handler(std::bind(&websocket_endpoint::on_message, this, std::placeholders::_1, std::placeholders::_2));
+        m_endpoint.set_close_handler(std::bind(&websocket_endpoint::on_close, this, std::placeholders::_1));
+    }
+
+    void on_open(websocketpp::connection_hdl hdl) {
+        std::cout << "Connected" << std::endl;
+    }
+
+    void on_message(websocketpp::connection_hdl hdl, message_ptr msg) {
+        std::cout << "Received: " << msg->get_payload() << std::endl;
+    }
+
+    void on_close(websocketpp::connection_hdl hdl) {
+        std::cout << "Connection closed" << std::endl;
+    }
+
+    void run(const std::string& uri) {
+        websocketpp::lib::error_code ec;
+        client::connection_ptr con = m_endpoint.get_connection(uri, ec);
+        if (ec) {
+            std::cout << "Could not create connection because: " << ec.message() << std::endl;
+            return;
+        }
+
+        m_endpoint.connect(con);
+        m_endpoint.run();
+    }
+
+private:
+    client m_endpoint;
+};
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cout << "Usage: " << argv[0] << " <ws://host:port/path>" << std::endl;
+        return 1;
+    }
+
+    std::string uri = argv[1];
+
+    websocket_endpoint endpoint;
+    endpoint.run(uri);
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- remove duplicate websocket tracker source
- reference the tracker in its dedicated folder

## Testing
- `g++ -std=c++11 network-tracker/websocket_tracker.cpp -o network-tracker/websocket_tracker -lboost_system -pthread`
- `./network-tracker/websocket_tracker ws://echo.websocket.events` *(fails: no output, likely due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_b_68539d43b2fc83238b646c9386ed1e53